### PR TITLE
Add proxy for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,8 @@
-# Template Repo
+# ITSG33 control panel
 
-[Français](https://github.com/PHACDataHub/DSCO-naming-app/edit/main/README.md#dsco-application-de-g%C3%A9n%C3%A9ration-de-nom)
+This project is aimed at helping people understand and use the [ITSG-33 control catalogue](https://www.cyber.gc.ca/en/guidance/annex-3a-security-control-catalogue-itsg-33).
 
-## ⚠️ DISCLAIMER
+## Running it
 
-This project is under heavy development and is not by any means, complete. Due to the nature of the development process, the language is currently being handled automatically and therefore may not be accurate. There are many aspects of the project that may not currently work and/or does not directly reflect the technologies that the government has, currently, or will use.
-
-## 📈 Project Management and Tracker
-
-
-
-## 🤔 Problem statement that we are trying to solve
-
-## ❓ The tech stack
-
-## 👨‍💻 Getting Started
-[GitHub Codespaces](https://github.com/PHACDataHub/Wiki/wiki/How-to-use-GitHub-Codespaces)
-
-To dive into the code, read the wiki above on how to use GitHub Codespaces.
-
-## 🤓 Want to contribute?
-
-## 📄 License
-Unless otherwise noted, the source code of this project is covered under Crown Copyright, Government of Canada, and is distributed under the [MIT License](LICENSE).
-
-The Canada wordmark and related graphics associated with this distribution are protected under trademark law and copyright law. No permission is granted to use them outside the parameters of the Government of Canada's corporate identity program. For more information, see [Federal identity requirements](https://www.canada.ca/en/treasury-board-secretariat/topics/government-communications/federal-identity-requirements.html).
-
-______________________
-______________________
-______________________
-
-# DSCO Application 
-
-## ⚠️ CLAUSE DE NON-RESPONSABILITÉ
-Ce projet est en plein développement et n'est en aucun cas terminé. En raison de la nature du processus de développement, le langage est actuellement géré automatiquement et peut donc ne pas être précis. De nombreux aspects du projet peuvent ne pas fonctionner actuellement et/ou ne reflètent pas directement les technologies que le gouvernement utilise actuellement ou utilisera.
+In the project root you can run the project using [docker compose](https://docs.docker.com/compose/) using the command `docker-compose up`.
+The ui will be reachable via `localhost:3000`, the api via `localhost:3000/graphql` and the database on `localhost:8529`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,19 @@
 version: "3.8"
+name: itsg
 services:
+  # proxies localhost:3000 to containers based on rules in envoy.yaml
+  envoy:
+    image: envoyproxy/envoy-distroless-dev
+    entrypoint: envoy
+    command: [ "-l", "warn", "-c", "/etc/envoy.yaml", "--service-cluster", "envoy"]
+    volumes:
+      - ./envoy.yaml:/etc/envoy.yaml # Envoy configuration
+    expose:
+      - "3000" # Forward to proxied apps
+      - "3001" # Envoy admin page
+    ports:
+      - "3000:3000"
+      - "3001:3001"
   arangodb:
     image: arangodb:3.11
     environment:
@@ -9,17 +23,17 @@ services:
   ui:
     build: ui
     ports:
-      - 8080:8080
+      - 8080
   api:
     build: api
     environment:
       DB_URL: http://arangodb:8529
-      DB_NAME: itgs33
+      DB_NAME: itsg33
       DB_USER: root
       DB_PASS: openSesame
       PORT: 4000
     ports:
-      - 4000:4000
+      - 4000
     
     
     

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,0 +1,87 @@
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 3000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: AUTO
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+             "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          upgrade_configs:
+          - upgrade_type: websocket
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: backend
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/graphql" }
+                route: { cluster: api }
+              - match: { prefix: "/" }
+                route: { cluster: ui }
+  clusters:
+  - name: ui
+    connect_timeout: 0.25s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: ui
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: ui
+                port_value: 8080
+  - name: api
+    connect_timeout: 0.40s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: api
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: api
+                port_value: 4000
+  - name: arangodb
+    connect_timeout: 0.40s
+    type: strict_dns
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: arangodb
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: arangodb
+                port_value: 8529
+
+layered_runtime:
+  layers:
+    - name: static_layer_0
+      static_layer:
+        envoy:
+          resource_limits:
+            listener:
+              example_listener_name:
+                connection_limit: 10000
+        overload:
+          global_downstream_max_connections: 50000
+
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 3001


### PR DESCRIPTION
This commit places the lightweight [envoy proxy](https://www.envoyproxy.io/) in front of the UI and API services so that they look and feel
 like a single service, just like they will in production.

Instructions for running this new setup with docker-compose have been added to a slimmed down readme.