### PR TITLE
Add live reloading for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,22 @@ services:
     ports:
       - 8529:8529
   ui:
-    build: ui
+    image: node:alpine
+    working_dir: /home/node/ui
+    entrypoint: npm
+    command: ["run", "start"]
     ports:
-      - 8080
+      - 3000
+    environment:
+      BROWSER: none
+    volumes:
+    - type: bind
+      source: ./ui
+      target: /home/node/ui
   api:
     build: api
+    # Auto reload when files change with watch mode
+    command: node --watch index.js
     environment:
       DB_URL: http://arangodb:8529
       DB_NAME: itsg33
@@ -34,6 +45,10 @@ services:
       PORT: 4000
     ports:
       - 4000
+    volumes:
+    - type: bind
+      source: ./api
+      target: /api
     
     
     

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -40,7 +40,7 @@ static_resources:
             address:
               socket_address:
                 address: ui
-                port_value: 8080
+                port_value: 3000
   - name: api
     connect_timeout: 0.40s
     type: strict_dns

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 COPY . .
 # install dep.


### PR DESCRIPTION
This commit adds bind mounts for the ui and api folders so that changes to the contents affect the containers. Additionally, both the ui and api have been set to hot reload: The ui is using the webpack dev server/hmr setup from CRA The api is using the new `--watch` option added in Node 18 to do hot reloading.
