### PR TITLE
Fix Apollo client error in App.test.js

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -9,12 +9,12 @@ function App() {
     <div className="App">
       <header className="App-header">
         <div className="header-sig">
-          <Phacsignature />
+          <Phacsignature language="fr" />
         </div>
         <h1>DSCO ITSG33 Filter</h1>
       </header>
 
-      <section class="alert alert-info">
+      <section className="alert alert-info">
         <h3>This is a work in progress.</h3>
         <p>Information may be incorrect or inaccurate.</p>
       </section>
@@ -22,7 +22,7 @@ function App() {
       <div className="getData">
       <GetAll />
       </div>
-   
+
       <footer>
         <div className="footer-wm">
           <Wordmark textColor="black" />

--- a/ui/src/App.test.js
+++ b/ui/src/App.test.js
@@ -1,8 +1,55 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import App from './App.js'
+import { GET_ALL_CONTROLS } from './graphql.js'
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+describe('<App/>', () => {
+  describe('given an instance of the Apollo client', () => {
+    it('displays a page with DSCO in the title', () => {
+      const mocks = [
+        {
+          request: {
+            query: GET_ALL_CONTROLS,
+          },
+          result: {
+            data: {
+              controlAll: [
+                {
+                  title: 'test',
+                  definition: 'test',
+                  family: 'test',
+                  id: '1',
+                  additionalGuidance: 'test',
+                  allocation: {
+                    department: 'test',
+                    itSecurityFunction: 'test',
+                    cioFunctionIncludingOps: 'test',
+                    physicalSecurityGroup: 'test',
+                    personnelSecurityGroup: 'test',
+                    programAndServiceDeliveryManagers: 'test',
+                    process: 'test',
+                    project: 'test',
+                    itProjects: 'test',
+                    facilityAndHardware: 'test',
+                    resourceAbstractionAndControlLayer: 'test',
+                    infrastructure: 'test',
+                    platform: 'test',
+                    application: 'test',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ]
+
+      render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <App />
+        </MockedProvider>,
+      )
+      const title = screen.getByText(/DSCO ITSG33 Filter/i)
+      expect(title).toBeInTheDocument()
+    })
+  })
+})

--- a/ui/src/Components/GetAll.js
+++ b/ui/src/Components/GetAll.js
@@ -1,123 +1,61 @@
-import React, { useState } from "react";
-import { useQuery, gql } from "@apollo/client";
-
-const GET_ALL_CONTROLS = gql`
-  query {
-    controlAll {
-      control
-      title
-      definition
-      family
-      id
-      additionalGuidance
-      allocation {
-        department
-        itSecurityFunction
-        cioFunctionIncludingOps
-        physicalSecurityGroup
-        personnelSecurityGroup
-        programAndServiceDeliveryManagers
-        process
-        project
-        itProjects
-        facilityAndHardware
-        resourceAbstractionAndControlLayer
-        infrastructure
-        platform
-        application
-      }
-    }
-  }
-`;
+import React, { useState } from 'react'
+import { useQuery } from '@apollo/client'
+import { GET_ALL_CONTROLS } from '../graphql.js'
 
 export default function GetAllControls() {
-  const [keyword, setKeyword] = useState("");
-  const [allocation, setAllocation] = useState("");
-  const { loading, error, data } = useQuery(GET_ALL_CONTROLS);
+  const [keyword, setKeyword] = useState('')
+  const [allocation, setAllocation] = useState('')
+  const { loading, error, data } = useQuery(GET_ALL_CONTROLS)
 
   const handleChange = (event) => {
-    const newKeyword = event.target.value;
-    setKeyword(newKeyword);
-  };
-
-  const handleAllocationChange = (event) => {
-    const newAllocation = event.target.value;
-    setAllocation(newAllocation);
+    const newKeyword = event.target.value
+    setKeyword(newKeyword)
   }
 
-  if (loading) return "Loading...";
-  if (error) return <pre>{error.message}</pre>;
+  const handleAllocationChange = (event) => {
+    const newAllocation = event.target.value
+    setAllocation(newAllocation)
+  }
+
+  if (loading) return 'Loading...'
+  if (error) return <pre>{error.message}</pre>
 
   const filteredControls = data.controlAll.filter((control) => {
     const isKeywordMatch =
-      control.control.toLowerCase().includes(keyword) ||
-      control.title.toLowerCase().includes(keyword);
+      control.control.toLowerCase().includes(keyword) || control.title.toLowerCase().includes(keyword)
 
-    if (allocation === "") {
-      return isKeywordMatch;
+    if (allocation === '') {
+      return isKeywordMatch
     }
 
-    const allocationValue = control.allocation[allocation];
-    return isKeywordMatch && allocationValue;
-  });
+    const allocationValue = control.allocation[allocation]
+    return isKeywordMatch && allocationValue
+  })
 
-  const numResults = filteredControls.length;
+  const numResults = filteredControls.length
 
   return (
     <div>
       <h2>Search by Keyword</h2>
 
       <div className="filter-options">
-        <input
-          type="text"
-          value={keyword}
-          onChange={handleChange}
-          placeholder="Search by keyword"
-        />
+        <input type="text" value={keyword} onChange={handleChange} placeholder="Search by keyword" />
         <select value={allocation} onChange={handleAllocationChange}>
           <option value="">All Allocations</option>
-          <option value="department">
-            Department
-          </option>
-          <option value="itSecurityFunction">
-            IT Security Function
-          </option>
-          <option value="cioFunctionIncludingOps">
-            CIO Function Including Ops
-          </option>
-          <option value="physicalSecurityGroup">
-            Physical Security Group
-          </option>
-          <option value="personnelSecurityGroup">
-            Personel Security Group
-          </option>
-          <option value="programAndServiceDeliveryManagers">
-            Program and Service Delivery Managers
-          </option>
-          <option value="process">
-            Process
-          </option>
-          <option value="project">
-            Project
-          </option>
-          <option value="itProjects">
-            IT Projects
-          </option>
-          <option value="facilityAndHardware">
-            Facility and Hardware
-          </option>
-          <option value="resourceAbstractionAndControlLayer">
-            Resource Abstraction and Control Layer
-          </option>
-          <option value="infrastructure">
-            Infrastructure
-          </option>
-          <option value="platform">
-            Platform
-          </option>
-          <option value="application">
-            Application
-          </option>
+          <option value="department">Department</option>
+          <option value="itSecurityFunction">IT Security Function</option>
+          <option value="cioFunctionIncludingOps">CIO Function Including Ops</option>
+          <option value="physicalSecurityGroup">Physical Security Group</option>
+          <option value="personnelSecurityGroup">Personel Security Group</option>
+          <option value="programAndServiceDeliveryManagers">Program and Service Delivery Managers</option>
+          <option value="process">Process</option>
+          <option value="project">Project</option>
+          <option value="itProjects">IT Projects</option>
+          <option value="facilityAndHardware">Facility and Hardware</option>
+          <option value="resourceAbstractionAndControlLayer">Resource Abstraction and Control Layer</option>
+          <option value="infrastructure">Infrastructure</option>
+          <option value="platform">Platform</option>
+          <option value="application">Application</option>
         </select>
       </div>
       <div>
@@ -141,7 +79,6 @@ export default function GetAllControls() {
                       ))}
                   </ul>
                 </div>
-
               </div>
             ))
           ) : (
@@ -150,5 +87,5 @@ export default function GetAllControls() {
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/ui/src/graphql.js
+++ b/ui/src/graphql.js
@@ -1,0 +1,30 @@
+import { gql } from '@apollo/client'
+
+export const GET_ALL_CONTROLS = gql`
+  query {
+    controlAll {
+      control
+      title
+      definition
+      family
+      id
+      additionalGuidance
+      allocation {
+        department
+        itSecurityFunction
+        cioFunctionIncludingOps
+        physicalSecurityGroup
+        personnelSecurityGroup
+        programAndServiceDeliveryManagers
+        process
+        project
+        itProjects
+        facilityAndHardware
+        resourceAbstractionAndControlLayer
+        infrastructure
+        platform
+        application
+      }
+    }
+  }
+`


### PR DESCRIPTION
This commit adds Apollo's [MockedProvider component](https://www.apollographql.com/docs/react/development-testing/testing/#the-mockedprovider-component) to the App test to resolve the error that was being produced.
Components using Apollo client depend on the client to be available via
 the context.
This client is used to fetch data from the API.
When testing the MockedProvider is wrapped around components that need a client and test data is passed to the mocks prop allowing the MockedProvider to simulate an interaction with the API. As part of this refactor the queries are extracted into a separate file to allow imports into both the tests and the GetAll component.